### PR TITLE
# Version 3:

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,7 +39,9 @@ app.get('/blogs', (req, res) => {
 
 
 app.get('/blogs/subjects', (req, res) => {
-   res.render('subjects')
+   Blog.find({}, (err, blog) => {
+      res.render('subjects', {blog: blog})
+   })
 })
 
 app.post('/blogs', (req, res) => {

--- a/readme.md
+++ b/readme.md
@@ -5,3 +5,8 @@
 
 # Version 2: Day #2 of JRS Code School Blog Exercise
 # Going back to Bootstrap since I understand it better than Semantic UI
+
+# Version 3:
+   View Subjects currently generates an error.
+      Moved the res.render() inside the Blog.find() function. Scope issue.
+      Now each subject shows up as a paragraph.

--- a/views/subjects.ejs
+++ b/views/subjects.ejs
@@ -3,7 +3,9 @@
 <h1>You are on the Subjects Show Page</h1>
 
 <p>
-   <%= blog %>
+  <% blog.forEach((e) => { %>
+  <p> <%= e.subject %> </p>
+  <% }) %>
 </p>
 
 <% include partials/footer %>


### PR DESCRIPTION
   View Subjects currently generates an error.
      Moved the res.render() inside the Blog.find() function. Scope issue.
      Now each subject shows up as a paragraph.